### PR TITLE
Fix querystring params bug

### DIFF
--- a/lib/jinqu-axios.ts
+++ b/lib/jinqu-axios.ts
@@ -4,6 +4,9 @@ import { AjaxOptions, AjaxResponse, IAjaxProvider, Value } from "jinqu";
 export class AxiosAjaxProvider implements IAjaxProvider {
 
     public ajax<T>(o: AjaxOptions): PromiseLike<Value<T> & AjaxResponse<AxiosResponse>> {
+        if (Array.isArray(o.params)) {
+            o.params = Object.assign({}, ...o.params.map(item => ({ [item["key"]]: item["value"] })))
+        }
         return axios.request<T>(o)
             .then((r) => ({ value: r.data, response: r })) as any;
     }


### PR DESCRIPTION
Axios querystring params must be a plain object or a URLSearchParams object. Linquest sends params as an array. This update converts array to a plain object.
